### PR TITLE
替换cookie文件夹的默认位置

### DIFF
--- a/MiniBlink/BlinkBrowser.cs
+++ b/MiniBlink/BlinkBrowser.cs
@@ -501,7 +501,7 @@ namespace MiniBlinkPinvoke
 
             //BlinkBrowserPInvoke.wkeSetTransparent(handle, true);
             BlinkBrowserPInvoke.wkeSetCookieEnabled(handle, true);
-            CookiePath = Application.StartupPath + "\\cookie\\";
+            CookiePath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "cookie");
             if (!Directory.Exists(CookiePath))
             {
                 Directory.CreateDirectory(CookiePath);


### PR DESCRIPTION
如果在COM Addin等dll加载形式下，他的Application.StartUpPath是主exe的目录，而他的主exe目录是禁止写入的状态，应该使用 Assembly.GetExecutingAssembly() 来确保相对位置，以确保有写入权限，或者其实应该默认到临时目录下，以确保绝对有写入权限的。